### PR TITLE
👷 Monthly actions version update

### DIFF
--- a/.github/workflows/repo-actions_updater.yml
+++ b/.github/workflows/repo-actions_updater.yml
@@ -26,7 +26,7 @@ jobs:
         # saadmk11/github doesn't work on Self hosted runner yet 
         runs-on: ubuntu-latest #${{ contains(needs.self-hosted-status.outputs.runner-status, 'online') && 'self-hosted' || 'ubuntu-latest' }}
         steps:
-          - uses: actions/checkout@v4.1.6
+          - uses: actions/checkout@v4.1.7
             with:
               # Classic personal access token with repo and workflow scope
               token: ${{ secrets.REPO_WORKFLOW_ACCESS_TOKEN }} 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
