### PR TITLE
👷 Monthly actions version update

### DIFF
--- a/.github/workflows/repo-actions_updater.yml
+++ b/.github/workflows/repo-actions_updater.yml
@@ -26,7 +26,7 @@ jobs:
         # saadmk11/github doesn't work on Self hosted runner yet 
         runs-on: ubuntu-latest #${{ contains(needs.self-hosted-status.outputs.runner-status, 'online') && 'self-hosted' || 'ubuntu-latest' }}
         steps:
-          - uses: actions/checkout@v4.2.2
+          - uses: actions/checkout@v6.0.2
             with:
               # Classic personal access token with repo and workflow scope
               token: ${{ secrets.REPO_WORKFLOW_ACCESS_TOKEN }} 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)** on 2026-01-09T19:53:28Z
