### PR TITLE
Pin Poetry to 2.2.1 to fix segfault on self-hosted runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,8 @@ runs:
 
     - name: Install Poetry
       uses: snok/install-poetry@v1.4.1
+      with:
+        version: "2.2.1"
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## What
Pin Poetry to `2.2.1` in the composite action's `Install Poetry` step.

## Why
Without a version pin, `snok/install-poetry` installs the latest Poetry (currently 2.4.x), which segfaults (exit 139) during `secretstorage`/keyring import on the headless self-hosted `samba` runners. This is blocking CI across multiple downstream repos (e.g. `aprilaire-backend/recharge_integration` — every open PR + main).

Fixes #7.

## Changes
- `action.yml`: add `with: version: "2.2.1"` to the `Install Poetry` step.

## Test plan
- [ ] CI on a downstream PR (e.g. `aprilaire-backend#306`) using this branch passes `poetry install` on a self-hosted runner.
- [ ] After merge, tag a new release of this action so downstream repos can bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)